### PR TITLE
Improve memory usage during API calls

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -237,6 +237,9 @@ class ApiClient
         } else {
             curl_setopt($curl, CURLOPT_VERBOSE, 0);
         }
+        
+        // Release memory used for initilizing curl.
+        unset($postData);
 
         // obtain the HTTP response headers
         curl_setopt($curl, CURLOPT_HEADER, 1);


### PR DESCRIPTION
When you're dealing with large PDFs, you might hit the memory limit during PDF generation. There's a way to seriously lower the memory consumption during api calls by freeing the memory used by temp variables that were used to initialize curl.

In my case, that variable contained data with a 25MB worth of RAM and I was hitting the memory limit when retrieving the request result.