### PR TITLE
Add support for Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
Guzzle 7 is mostly backwards-compatible with Guzzle 6 (see [full upgrade guide](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md)). This change Works On My Machine (TM).

Fixes #23.