### PR TITLE
Consistency for all scripts to define Bash script

### DIFF
--- a/script/clean
+++ b/script/clean
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
 

--- a/script/generate_language
+++ b/script/generate_language
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
 

--- a/script/post_generate_language
+++ b/script/post_generate_language
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
It seems that scripts define Bash or Sh. To be consistency, I think it should be proper to let all scripts be `Bash` script.