### PR TITLE
Change uses of getRealPath to getPathname

### DIFF
--- a/lib/DocApi.php
+++ b/lib/DocApi.php
@@ -392,7 +392,7 @@ class DocApi
     public function createDoc($doc)
     {
         list($response) = $this->createDocWithHttpInfo($doc);
-        return file_get_contents($response->getRealPath());
+        return file_get_contents($response->getPathname());
         // return $response;
     }
 
@@ -1410,7 +1410,7 @@ class DocApi
     public function getAsyncDoc($id)
     {
         list($response) = $this->getAsyncDocWithHttpInfo($id);
-        return file_get_contents($response->getRealPath());
+        return file_get_contents($response->getPathname());
         // return $response;
     }
 


### PR DESCRIPTION
Why is this change needed?
--------------------------
A Windows user reported[1] the error

`file_get_contents(): Filename cannot be empty in path\vendor\docraptor\docraptor\lib\DocApi.php on line 395`

when running 3.0.0. They tried substituting getPathname for getRealPath and found it made the agent work for theem.

How does it address the issue?
------------------------------
I changed getRealPath to getPathname. All the existing tests continue to pass and this will hopefully resolve the customer's issue.

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------
1 - https://github.com/DocRaptor/docraptor-php/issues/28